### PR TITLE
we fingerprint the *public* key, not the private one

### DIFF
--- a/_posts/blog/2013-09-24-urbit-intro.markdown
+++ b/_posts/blog/2013-09-24-urbit-intro.markdown
@@ -281,7 +281,7 @@ the ship's hierarchical prefix, or "flagship."  Mere submarine are
 independent; carriers create cruisers; cruisers create
 destroyers; destroyers create yachts.  
 
-A submarine is the fingerprint of its own private key; a carrier's
+A submarine is the fingerprint of its own public key; a carrier's
 fingerprint is predefined in the kernel.  Anyone can create any
 number of 128-bit submarines, whose free and independent
 society the 64-bit naval hierarchy cannot interfere with.  And


### PR DESCRIPTION
Fixing a simple typo/thinko in the blog post.
