### PR TITLE
Added links to next page in documentation

### DIFF
--- a/_posts/doc/2013-11-18-urbit-is-easy-ch1.markdown
+++ b/_posts/doc/2013-11-18-urbit-is-easy-ch1.markdown
@@ -429,3 +429,5 @@ simply type
     &
 
 and type `?` for help.
+
+[**Next**: Intro to Nock](urbit-is-easy-ch2.html)

--- a/_posts/doc/2013-11-18-urbit-is-easy-ch2.markdown
+++ b/_posts/doc/2013-11-18-urbit-is-easy-ch2.markdown
@@ -312,3 +312,6 @@ We can also build nouns in which every atom is its own axis:
 
 Once you've spent enough time programming in Urbit, you'll know
 these axes in your dreams.
+
+
+[**Next**: Nock is Easy](urbit-is-easy-ch3.html)

--- a/_posts/doc/2013-11-18-urbit-is-easy-ch3.markdown
+++ b/_posts/doc/2013-11-18-urbit-is-easy-ch3.markdown
@@ -339,3 +339,6 @@ So we have:
 
 If you have a really fine instinctive sense of Nock, you might
 understand what `9` is for.  Otherwise, don't worry for now.
+
+
+[Next: Using Nock](urbit-is-easy-ch4.html)

--- a/_posts/doc/2013-11-18-urbit-is-easy-ch4.markdown
+++ b/_posts/doc/2013-11-18-urbit-is-easy-ch4.markdown
@@ -617,3 +617,6 @@ might as well use Hoon to calculate axes:
 
 Ie, `(peg a b)` is `/b` within `/a`.  Writing Nock without this
 would be pretty tough...
+
+
+[Next: Hoon Attacks](urbit-is-easy-ch5.html)


### PR DESCRIPTION
I was tired of going back to the main Documentation page, so this PR adds a link to
the next chapter at the bottom of each page in the documentation.
