### PR TITLE
Fix inconsistant bolding

### DIFF
--- a/_posts/doc/2013-11-18-urbit-is-easy-ch3.markdown
+++ b/_posts/doc/2013-11-18-urbit-is-easy-ch3.markdown
@@ -341,4 +341,4 @@ If you have a really fine instinctive sense of Nock, you might
 understand what `9` is for.  Otherwise, don't worry for now.
 
 
-[Next: Using Nock](urbit-is-easy-ch4.html)
+[**Next**: Using Nock](urbit-is-easy-ch4.html)

--- a/_posts/doc/2013-11-18-urbit-is-easy-ch4.markdown
+++ b/_posts/doc/2013-11-18-urbit-is-easy-ch4.markdown
@@ -619,4 +619,4 @@ Ie, `(peg a b)` is `/b` within `/a`.  Writing Nock without this
 would be pretty tough...
 
 
-[Next: Hoon Attacks](urbit-is-easy-ch5.html)
+[**Next**: Hoon Attacks](urbit-is-easy-ch5.html)


### PR DESCRIPTION
Half of the **Next:** labels were bold; the other half were not -- let's make them consistent.
