### PR TITLE
Added automake as dependency for compiling on Mac

### DIFF
--- a/setup/index.md
+++ b/setup/index.md
@@ -67,7 +67,7 @@ Follow the instructions on the GitHub page, then proceed to "Run" below.
      Otherwise, `ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"`
      will install it.
 
-     And follow up with `brew install git gmp libsigsegv openssl`
+     And follow up with `brew install automake git gmp libsigsegv openssl`
 
      This will ask you for the root password, which ideally you know.
 


### PR DESCRIPTION
```
✱ ryan ~/playground/urbit master ♥
✱ make
...
glibtoolize: putting macros in AC_CONFIG_MACRO_DIR, `m4'.
glibtoolize: linking file `m4/libtool.m4'
glibtoolize: linking file `m4/ltoptions.m4'
glibtoolize: linking file `m4/ltsugar.m4'
glibtoolize: linking file `m4/ltversion.m4'
glibtoolize: linking file `m4/lt~obsolete.m4'
+ aclocal -I m4
autogen.sh: line 44: aclocal: command not found
/bin/sh: ./configure: No such file or directory
make: *** [outside/libuv_0.11/Makefile] Error 127
```

Installed automake, and it compiled with 3 warnings, but other than that it works!

---

```
✱ ryan ~/playground/urbit master ♥
✱ make
...
src/parser.c:54:18: warning: unused variable 'telnet_parser_first_final' [-Wunused-const-variable]
static const int telnet_parser_first_final = 7;
                 ^
src/parser.c:55:18: warning: unused variable 'telnet_parser_error' [-Wunused-const-variable]
static const int telnet_parser_error = -1;
                 ^
src/parser.c:57:18: warning: unused variable 'telnet_parser_en_main' [-Wunused-const-variable]
static const int telnet_parser_en_main = 7;
                 ^
3 warnings generated.
ar rcs build/libanachronism.a build/nvt.o build/parser.o
    LD  bin/vere
ld: warning: directory not found for option '-L/opt/local/lib'
```
